### PR TITLE
absolute link to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Napari text layer for bio-image annotation.
 
-![](GIFs/annot.gif)
+![](https://github.com/hanjinliu/napari-text-layer/raw/main/GIFs/annot.gif)
 
-![](GIFs/age.gif)
+![](https://github.com/hanjinliu/napari-text-layer/raw/main/GIFs/age.gif)
 
 ### Installation
 


### PR DESCRIPTION
Hi @hanjinliu ,

it's just me again fixing a link to the demo video which is not visible on [napari hub plugin page](https://www.napari-hub.org/plugins/napari-text-layer) otherwise. Great work otherwise! :-)

Best,
Robert