### PR TITLE
Add napari and numpy to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author_email="liuhanjin-sc@g.ecc.u-tokyo.ac.jp",
     license="BSD 3-Clause",
     download_url="https://github.com/hanjinliu/napari-text-layer",
+    install_requires=['napari'],
     entry_points={"napari.plugin": "napari-text-layer = napari_text_layer"},
     packages=find_packages(),
     classifiers=["Framework :: napari",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email="liuhanjin-sc@g.ecc.u-tokyo.ac.jp",
     license="BSD 3-Clause",
     download_url="https://github.com/hanjinliu/napari-text-layer",
-    install_requires=['napari'],
+    install_requires=['napari', 'numpy'],
     entry_points={"napari.plugin": "napari-text-layer = napari_text_layer"},
     packages=find_packages(),
     classifiers=["Framework :: napari",


### PR DESCRIPTION
Hi team,

My name is Draga and I am a CZI contractor working on napari.

As part of our work on the [new napari plugin engine](https://napari.org/plugins/stable/npe2_getting_started.html), we’ve been running some automated tests to see whether plugins will be easily converted to the new plugin engine. While running these tests, we noticed that your plugin fails to be imported after installation in a fresh environment due to some missing requirements. You can see details in [this github action run](https://github.com/napari/npe2/runs/4476905706?check_suite_focus=true).

This PR therefore adds `napari` and `numpy` to your install requirements so that users can install your plugin more confidently. 

Note that this may not be a complete list - to check whether your plugin can be easily installed on other machines, we recommend using GitHub workflows to test your plugin in a fresh environment - [the napari plugin cookiecutter](https://github.com/napari/cookiecutter-napari-plugin/blob/main/%7B%7Bcookiecutter.plugin_name%7D%7D/.github/workflows/test_and_deploy.yml) provides an example of such a workflow.

If you believe this PR has been opened in error, please feel free to close it and let us know where we went wrong!
